### PR TITLE
Dynamic lora loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ hf_download/
 outputs/
 repo/
 loras/
+wildcards/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/core/generation.py
+++ b/core/generation.py
@@ -477,7 +477,7 @@ class VideoGenerator:
             end_latent = None # Only for keyframes
             height, width = 0, 0
 
-             if mode == "keyframes":
+         if mode == "keyframes":
                 if end_frame is None: raise ValueError("Keyframes mode requires End Frame.")
                 end_H, end_W, _= end_frame.shape
                 height, width = find_nearest_bucket(end_H, end_W, resolution=640)

--- a/core/generation.py
+++ b/core/generation.py
@@ -91,18 +91,17 @@ class VideoGenerator:
         Returns encoded prompts, poolers, masks, and negative versions.
         """
         from utils.prompt_parser import parse_sequential_prompts
-
+    
+        # Use the correct argument name 'cleaned_prompt_text' here
         prompts = parse_sequential_prompts(cleaned_prompt_text)
         if not prompts:
             debug("[Encode Multi] Warning: Cleaned prompt resulted in no sequential prompts. Using the cleaned prompt as a single prompt.")
-            prompts = [cleaned_prompt_text] # Fallback if splitting failed but text exists
+            # Use the input argument name here too for consistency if needed
+            prompts = [cleaned_prompt_text]
         elif len(prompts) == 1:
              debug(f"[Encode Multi] Only one prompt after sequential parse: '{prompts[0]}'")
         else:
              debug(f"[Encode Multi] Encoding {len(prompts)} sequential prompts derived from cleaned prompt.")
-        
-        prompts = parse_sequential_prompts(prompt_text)
-        debug(f"Encoding {len(prompts)} sequential prompts")
         
         # Initialize lists to store encodings
         llama_vecs = []

--- a/core/generation.py
+++ b/core/generation.py
@@ -212,7 +212,7 @@ class VideoGenerator:
         
         debug(f"[Prepare Inputs] Text Encoder device: {self.model_manager.text_encoder.device if self.model_manager.text_encoder else 'None'}")
         debug(f"[Prepare Inputs] Text Encoder 2 device: {self.model_manager.text_encoder_2.device if self.model_manager.text_encoder_2 else 'None'}")                          
-        debug(f"[Prepare Inputs] BEFORE POS ENCODE - Prompt: '{prompt}'")
+        debug(f"[Prepare Inputs] BEFORE POS ENCODE - Prompt: '{cleaned_prompt}'")
         
         lv, cp = encode_prompt_conds(
             cleaned_prompt, # Use the cleaned prompt here

--- a/core/generation.py
+++ b/core/generation.py
@@ -477,7 +477,7 @@ class VideoGenerator:
             end_latent = None # Only for keyframes
             height, width = 0, 0
 
-         if mode == "keyframes":
+            if mode == "keyframes":
                 if end_frame is None: raise ValueError("Keyframes mode requires End Frame.")
                 end_H, end_W, _= end_frame.shape
                 height, width = find_nearest_bucket(end_H, end_W, resolution=640)

--- a/core/generation.py
+++ b/core/generation.py
@@ -26,6 +26,9 @@ from diffusers_helper.utils import crop_or_pad_yield_mask, soft_append_bcthw
 from diffusers_helper.pipelines.k_diffusion_hunyuan import sample_hunyuan
 from ui.style import make_progress_bar_html
 
+from utils.prompt_parser import LoraPromptProcessor, SequentialPromptProcessor, apply_prompt_processors
+from utils.lora_utils import LoRAConfig # Potentially needed for type hints if used directly
+
 class VideoGenerator:
     """Handles all video generation functionality"""
     def __init__(self, model_manager, outputs_folder='./outputs/'):
@@ -82,12 +85,21 @@ class VideoGenerator:
         from utils.video_utils import extract_frames_from_video as extract_frames
         return extract_frames(video_path, num_frames, from_end, max_resolution)
     
-    def encode_multiple_prompts(self, prompt_text, n_prompt, cfg, llm_weight=1.0, clip_weight=1.0):
+    def encode_multiple_prompts(self, cleaned_prompt_text, n_prompt, cfg, llm_weight=1.0, clip_weight=1.0):
         """
         Encode multiple prompts for sequential generation.
         Returns encoded prompts, poolers, masks, and negative versions.
         """
         from utils.prompt_parser import parse_sequential_prompts
+
+        prompts = parse_sequential_prompts(cleaned_prompt_text)
+        if not prompts:
+            debug("[Encode Multi] Warning: Cleaned prompt resulted in no sequential prompts. Using the cleaned prompt as a single prompt.")
+            prompts = [cleaned_prompt_text] # Fallback if splitting failed but text exists
+        elif len(prompts) == 1:
+             debug(f"[Encode Multi] Only one prompt after sequential parse: '{prompts[0]}'")
+        else:
+             debug(f"[Encode Multi] Encoding {len(prompts)} sequential prompts derived from cleaned prompt.")
         
         prompts = parse_sequential_prompts(prompt_text)
         debug(f"Encoding {len(prompts)} sequential prompts")
@@ -172,8 +184,8 @@ class VideoGenerator:
         
         return llama_vecs, clip_poolers, llama_masks, llama_vec_n, clip_pooler_n, llama_mask_n
     
-    def prepare_inputs(self, input_image, prompt, n_prompt, cfg, gaussian_blur_amount=0.0,
-                      llm_weight=1.0, clip_weight=1.0):
+    def prepare_inputs(self, input_image, cleaned_prompt, n_prompt, cfg, gaussian_blur_amount=0.0,
+                   llm_weight=1.0, clip_weight=1.0):
         """Prepare text embeddings, poolers, masks, and image tensors"""
         if input_image is None:
             raise ValueError("Input image required for this mode.")
@@ -192,7 +204,7 @@ class VideoGenerator:
             )
             
         # --- Text Encoding ---
-        debug(f"[Prepare Inputs] Encoding prompt: '{prompt}'")
+        debug(f"[Prepare Inputs] Using cleaned prompt for encoding: '{cleaned_prompt}'")
         debug(f"[Prepare Inputs] Encoding negative prompt: '{n_prompt}'")
         if not self.model_manager.high_vram:
             mem_utils.fake_diffusers_current_device(self.model_manager.text_encoder, gpu)
@@ -203,7 +215,7 @@ class VideoGenerator:
         debug(f"[Prepare Inputs] BEFORE POS ENCODE - Prompt: '{prompt}'")
         
         lv, cp = encode_prompt_conds(
-            prompt,
+            cleaned_prompt, # Use the cleaned prompt here
             self.model_manager.text_encoder,
             self.model_manager.text_encoder_2,
             self.model_manager.tokenizer,
@@ -354,6 +366,56 @@ class VideoGenerator:
         t_start = time.time()
         timings = {"latent_encoding": 0, "step_times": [], "generation_time": 0, "vae_decode_time": 0, "total_time": 0}
 
+        # ============ Prompt Processing & Dynamic LoRA Loading ============
+        debug(f"[Generator] Raw prompt received: '{prompt}'")
+        
+        # 1. Initialize Prompt Processors
+        prompt_processors = [
+            LoraPromptProcessor(),       # Extracts LoRAs and cleans the prompt
+            SequentialPromptProcessor() # Extracts sequential info (doesn't clean further)
+            # Add other processors here if needed in the future
+        ]
+        
+        # 2. Apply Processors
+        cleaned_prompt, extracted_data = apply_prompt_processors(prompt, prompt_processors)
+        
+        # 3. Extract LoRA Configs
+        dynamic_lora_configs = extracted_data.get("lora", {}).get("lora_configs", [])
+        debug(f"[Generator] Extracted {len(dynamic_lora_configs)} dynamic LoRA configs from prompt.")
+        
+        # 4. Apply Dynamic LoRAs via ModelManager
+        # Ensure models (especially transformer) are loaded before applying LoRAs
+        self.model_manager.ensure_all_models_loaded() # Crucial check
+        
+        try:
+            applied_dynamic_loras, failed_dynamic_loras = self.model_manager.set_dynamic_loras(dynamic_lora_configs)
+            # Optional: Handle failures if needed (e.g., notify user)
+            if failed_dynamic_loras:
+                debug(f"[Generator] WARNING: Failed to apply {len(failed_dynamic_loras)} dynamic LoRAs.")
+                # You could add a UI message here if the stream exists
+                # if self.stream:
+                #     fail_msg = ", ".join([f"'{os.path.basename(c.path)}' ({c.error})" for c in failed_dynamic_loras])
+                #     self.stream.output_queue.push(('progress', (None, f"⚠️ Failed LoRAs: {fail_msg}", "")))
+        except RuntimeError as lora_error:
+             # Handle critical failure if --lora-skip-fail is False
+            debug(f"[Generator] CRITICAL LoRA Error: {lora_error}")
+            debug(traceback.format_exc())
+            if self.stream:
+                 self.stream.output_queue.push(('progress', (None, f"❌ LoRA Error: {lora_error}. Generation stopped.", "")))
+                 self.stream.output_queue.push(('end', 'lora_error'))
+            # Clean up models before returning None
+            if not self.model_manager.high_vram:
+                mem_utils.unload_complete_models(
+                    self.model_manager.text_encoder, self.model_manager.text_encoder_2,
+                    self.model_manager.image_encoder, self.model_manager.vae,
+                    self.model_manager.transformer
+                )
+            return None # Stop generation
+        
+        debug(f"[Generator] Using cleaned prompt for generation: '{cleaned_prompt}'")
+        # ===============================================================
+
+        
         # Extract the frame_overlap
         frame_overlap = config.get('frame_overlap', 0)
         debug(f"Using frame overlap: {frame_overlap}")
@@ -376,7 +438,7 @@ class VideoGenerator:
             debug(f"Simple Mode | window=9 | frames/sec=33 | total_frames={total_frames} | sections={total_sections}")
 
         # Check if we're using sequential prompting
-        prompts = parse_sequential_prompts(prompt)
+        prompts = parse_sequential_prompts(cleaned_prompt)
         use_sequential = len(prompts) > 1
         
         # Initialize variables for sequential prompts
@@ -395,7 +457,7 @@ class VideoGenerator:
             )
 
             # reversed to correct order of output
-            if not should_reverse_prompts:
+            if should_reverse_prompts:
                 debug(f"Reversing sequential prompts for {mode} mode")
                 prompts = list(reversed(prompts))
                 
@@ -415,7 +477,7 @@ class VideoGenerator:
             end_latent = None # Only for keyframes
             height, width = 0, 0
 
-            if mode == "keyframes":
+             if mode == "keyframes":
                 if end_frame is None: raise ValueError("Keyframes mode requires End Frame.")
                 end_H, end_W, _= end_frame.shape
                 height, width = find_nearest_bucket(end_H, end_W, resolution=640)
@@ -451,7 +513,7 @@ class VideoGenerator:
                     mem_utils.load_model_as_complete(self.model_manager.text_encoder_2, gpu)
                     
                 lv, cp = encode_prompt_conds(
-                    prompt, self.model_manager.text_encoder, self.model_manager.text_encoder_2,
+                    cleaned_prompt, self.model_manager.text_encoder, self.model_manager.text_encoder_2,
                     self.model_manager.tokenizer, self.model_manager.tokenizer_2
                 )
                 
@@ -496,7 +558,7 @@ class VideoGenerator:
                 # --- Prepare inputs using common function ---
                 # ensure prepare_inputs correctly calls encode_prompt_conds with all managers
                 _, input_tensor, lv, cp, lv_n, cp_n, m, m_n, height, width = self.prepare_inputs(
-                    anchor_np, prompt, n_prompt, cfg, gaussian_blur_amount, llm_weight, clip_weight
+                    anchor_np, cleaned_prompt, n_prompt, cfg, gaussian_blur_amount, llm_weight, clip_weight
                 )
                 
                 # --- VAE Encode ---
@@ -519,7 +581,7 @@ class VideoGenerator:
                 
                 # --- Prepare inputs using common function ---
                 inp_np, input_tensor, lv, cp, lv_n, cp_n, m, m_n, height, width = self.prepare_inputs(
-                    input_image, prompt, n_prompt, cfg, gaussian_blur_amount, llm_weight, clip_weight
+                    input_image, cleaned_prompt, n_prompt, cfg, gaussian_blur_amount, llm_weight, clip_weight
                 )
                 
                 # --- VAE Encode ---
@@ -560,7 +622,7 @@ class VideoGenerator:
                 
                 # Now encode all prompts
                 seq_llama_vecs, seq_clip_poolers, seq_llama_masks, seq_llama_vec_n, seq_clip_pooler_n, seq_llama_mask_n = \
-                    self.encode_multiple_prompts(prompt, n_prompt, cfg, llm_weight, clip_weight)
+                    self.encode_multiple_prompts( cleaned_prompt, n_prompt, cfg, llm_weight, clip_weight)
                 
                 # We'll keep using the original negative prompt encodings
                 # as they apply to all prompts
@@ -725,7 +787,7 @@ class VideoGenerator:
                 debug(f"  CFG scales: cfg={cfg}, gs={gs}, rs={rs}")
 
                 # Find the section to determine which prompt to use
-                if use_sequential and seq_llama_vecs is not None:
+                if use_sequential and seq_llama_vecs is None:
                     # Calculate which prompt to use
                     # Remember sections are processed in reverse order (end→start)
                     # section is from your loop_iterator which should match the current section index

--- a/models/model_loader.py
+++ b/models/model_loader.py
@@ -4,20 +4,33 @@ import os
 from utils.common import debug
 from utils.memory_utils import (
     cpu, gpu, unload_complete_models, load_model_as_complete,
-    DynamicSwapInstaller, fake_diffusers_current_device, get_cuda_free_memory_gb
+    DynamicSwapInstaller, fake_diffusers_current_device, get_cuda_free_memory_gb,
+    clear_cuda_cache # Import clear_cuda_cache
 )
+# Import LoRA utilities
+from utils.lora_utils import LoRAConfig, load_lora, set_adapters, safe_adapter_name
+from typing import List, Tuple
 
 class ModelManager:
     """Manages loading, unloading, and access to AI models"""
     def __init__(self, high_vram=False, lora_configs=None, lora_skip_fail=False):
         self.high_vram = high_vram
-        self.lora_configs = lora_configs or []
         self.lora_skip_fail = lora_skip_fail
-        self.active_loras = []
-        self.failed_loras = []
         debug(f"ModelManager initialized with high_vram={high_vram}")
-            
-        # Model objects (existing code)
+
+        # Command-line LoRAs (loaded at startup)
+        self.cli_lora_configs: List[LoRAConfig] = lora_configs or []
+        self.applied_cli_loras: List[LoRAConfig] = [] # Track successfully applied CLI LoRAs
+        self.failed_cli_loras: List[LoRAConfig] = []  # Track failed CLI LoRAs
+
+        # Dynamic LoRAs (loaded via prompt)
+        self.dynamic_lora_configs: List[LoRAConfig] = [] # Track currently active dynamic LoRAs
+        self.failed_dynamic_loras: List[LoRAConfig] = [] # Track failed dynamic LoRAs from last attempt
+
+        # Combined active LoRAs (used for setting adapters)
+        self._active_loras: List[LoRAConfig] = [] # Internal combined list
+
+        # Model objects
         self.text_encoder = None
         self.text_encoder_2 = None
         self.tokenizer = None
@@ -26,36 +39,258 @@ class ModelManager:
         self.feature_extractor = None
         self.image_encoder = None
         self.transformer = None
-        
+
         # Model loading status
         self.models_loaded = False
 
-    def load_loras(self):
-        """
-        Load all requested LoRAs and activate their adapters.
-        """
-        if not self.lora_configs:
-            return
-        from utils.lora_utils import load_all_loras
-        self.active_loras, self.failed_loras = load_all_loras(
-            self.transformer,
-            self.lora_configs,
-            skip_fail=self.lora_skip_fail
-        )
-        from utils.memory_utils import gpu, cpu
+    def _update_active_loras(self):
+        """Updates the internal _active_loras list from CLI and dynamic sources."""
+        self._active_loras = self.applied_cli_loras + self.dynamic_lora_configs
+        debug(f"Updated _active_loras: {len(self._active_loras)} total active adapters.")
+        # You could add more detailed logging here if needed
 
-        # Move transformer and all children to correct device:
-        if self.high_vram:
-            self.transformer.to(gpu)
-        else:
+    def _get_active_adapter_names(self) -> List[str]:
+        """Returns a list of adapter names currently considered active."""
+        return [lora.adapter_name for lora in self._active_loras if lora.adapter_name]
+
+    def load_cli_loras(self):
+        """
+        Load Command-Line Interface (CLI) specified LoRAs during initial setup.
+        """
+        if not self.cli_lora_configs:
+            debug("No CLI LoRAs specified to load.")
+            return
+
+        if not self.transformer:
+            debug("Cannot load CLI LoRAs: Transformer model not loaded yet.")
+            return
+
+        debug(f"Attempting to load {len(self.cli_lora_configs)} CLI LoRAs...")
+        applied_count = 0
+        failed_count = 0
+
+        # Make sure transformer is on CPU for initial LoRA loading
+        original_device = next(self.transformer.parameters()).device
+        if original_device != cpu:
+            debug(f"Temporarily moving transformer to CPU for CLI LoRA loading (currently on {original_device})")
             self.transformer.to(cpu)
-        # Diagnostic/verbose prints for CLI/log
-        if self.active_loras:
-            print("Loaded LoRAs: " + ", ".join([f"{c.path} (w={c.weight})" for c in self.active_loras]))
-        if self.failed_loras:
-            print("LoRAs failed to load:")
-            for c in self.failed_loras:
-                print(f"  {c.path} reason: {c.error}")
+
+        for idx, cfg in enumerate(self.cli_lora_configs):
+            base_name = os.path.splitext(os.path.basename(cfg.path))[0]
+            safe_name = safe_adapter_name(base_name)
+            adapter_name = f"cli_{idx}_{safe_name}" # Prefix to distinguish
+            cfg.adapter_name = adapter_name # Assign unique name
+
+            try:
+                debug(f"Loading CLI LoRA: '{cfg.path}' as '{adapter_name}'")
+                # Pass self.high_vram hint for potential future optimization
+                load_lora(self.transformer, cfg.path, adapter_name=adapter_name)
+                self.applied_cli_loras.append(cfg)
+                applied_count += 1
+            except Exception as e:
+                cfg.error = str(e)
+                self.failed_cli_loras.append(cfg)
+                failed_count += 1
+                error_msg = f"CLI LoRA Load Failed: Could not load '{os.path.basename(cfg.path)}' as '{adapter_name}'. Reason: {e}"
+                debug(f"[WARN] {error_msg}")
+                if not self.lora_skip_fail:
+                    debug("[ERROR] Stopping due to CLI LoRA load failure (--lora-skip-fail not set).")
+                     # Move transformer back before raising
+                    if original_device != cpu:
+                        debug(f"Moving transformer back to {original_device} before raising error.")
+                        self.transformer.to(original_device)
+                    raise RuntimeError(error_msg)
+                else:
+                    debug("[WARN] Skipping failed CLI LoRA as --lora-skip-fail is set.")
+
+        debug(f"Finished loading CLI LoRAs: {applied_count} succeeded, {failed_count} failed.")
+
+        # Update the combined active list
+        self._update_active_loras()
+
+        # Activate the combined set of adapters
+        if self._active_loras:
+             debug(f"Setting adapters for {len(self._active_loras)} total LoRAs (CLI only at this stage).")
+             set_adapters(
+                 self.transformer,
+                 [c.adapter_name for c in self._active_loras if c.adapter_name],
+                 [c.weight for c in self._active_loras if c.adapter_name],
+             )
+        else:
+             debug("No LoRAs active after CLI loading attempt.")
+
+        # Move transformer back to its original device or intended device based on VRAM mode
+        target_device = gpu if self.high_vram else cpu
+        if self.transformer.device != target_device:
+             debug(f"Moving transformer to target device: {target_device}")
+             self.transformer.to(target_device)
+        debug(f"Transformer final device after CLI LoRA load: {self.transformer.device}")
+
+        # Diagnostic prints for CLI/log
+        if self.applied_cli_loras:
+            print("Applied CLI LoRAs: " + ", ".join([f"{os.path.basename(c.path)} (w={c.weight}, name={c.adapter_name})" for c in self.applied_cli_loras]))
+        if self.failed_cli_loras:
+            print("CLI LoRAs failed to load:")
+            for c in self.failed_cli_loras:
+                print(f"  {os.path.basename(c.path)} reason: {c.error}")
+
+    def set_dynamic_loras(self, requested_configs: List[LoRAConfig]) -> Tuple[List[LoRAConfig], List[LoRAConfig]]:
+        """
+        Manages dynamically loaded LoRAs based on prompt requests.
+        Compares requested LoRAs with current dynamic LoRAs, unloads unused, loads new.
+
+        Args:
+            requested_configs: List of LoRAConfig objects extracted from the prompt.
+
+        Returns:
+            Tuple: (list of successfully applied/kept dynamic LoRAs, list of failed dynamic LoRAs)
+        """
+        if not self.transformer:
+            debug("Cannot set dynamic LoRAs: Transformer not loaded.")
+            return [], requested_configs # Return all as failed if no transformer
+
+        debug(f"Setting dynamic LoRAs. Requested: {len(requested_configs)}")
+        current_dynamic_configs = self.dynamic_lora_configs
+        current_dynamic_paths = {cfg.path: cfg for cfg in current_dynamic_configs}
+        requested_paths = {cfg.path: cfg for cfg in requested_configs}
+
+        loras_to_unload = []
+        loras_to_load = []
+        loras_to_keep = [] # Keep track of those staying, might need weight update
+        currently_applied_dynamic = []
+        failed_dynamic = []
+
+        # --- Identify changes ---
+        # Check currently loaded dynamic LoRAs
+        for path, current_cfg in current_dynamic_paths.items():
+            if path not in requested_paths:
+                loras_to_unload.append(current_cfg)
+                debug(f"  - Unload requested: {os.path.basename(path)} (adapter: {current_cfg.adapter_name})")
+            else:
+                # Exists in both, check if weight changed
+                requested_cfg = requested_paths[path]
+                if current_cfg.weight != requested_cfg.weight:
+                    debug(f"  - Weight change for {os.path.basename(path)}: {current_cfg.weight} -> {requested_cfg.weight}")
+                    # Update weight in the config we'll keep
+                    current_cfg.weight = requested_cfg.weight
+                loras_to_keep.append(current_cfg) # Keep this one
+
+        # Check requested LoRAs
+        for path, requested_cfg in requested_paths.items():
+             # Handle configs that failed normalization (don't try to load)
+            if requested_cfg.error:
+                debug(f"  - Skipping load for '{path}' due to previous error: {requested_cfg.error}")
+                failed_dynamic.append(requested_cfg)
+                continue # Skip to next requested config
+
+            # If not already loaded dynamically, mark for loading
+            if path not in current_dynamic_paths:
+                loras_to_load.append(requested_cfg)
+                debug(f"  - Load requested: {os.path.basename(path)} (weight: {requested_cfg.weight})")
+
+
+        # --- Perform Unloading ---
+        if loras_to_unload:
+            debug(f"Unloading {len(loras_to_unload)} dynamic LoRAs...")
+            original_device = next(self.transformer.parameters()).device
+            if original_device != cpu: # PEFT might require CPU for delete? Be safe.
+                debug("Moving transformer to CPU for adapter deletion.")
+                self.transformer.to(cpu)
+
+            for cfg in loras_to_unload:
+                try:
+                    if cfg.adapter_name:
+                        debug(f"Deleting adapter: {cfg.adapter_name}")
+                        self.transformer.delete_adapter(cfg.adapter_name)
+                    else:
+                         debug(f"Cannot delete LoRA for {cfg.path}, adapter name missing.")
+                except Exception as e:
+                    debug(f"Error deleting adapter {cfg.adapter_name} for {cfg.path}: {e}")
+            # Move back if needed
+            if original_device != cpu:
+                self.transformer.to(original_device)
+            debug("Finished unloading dynamic LoRAs.")
+
+
+        # --- Perform Loading ---
+        newly_loaded_loras = []
+        if loras_to_load:
+            debug(f"Loading {len(loras_to_load)} new dynamic LoRAs...")
+            original_device = next(self.transformer.parameters()).device
+            if original_device != cpu: # Move to CPU for loading consistency
+                debug("Moving transformer to CPU for new dynamic LoRA loading.")
+                self.transformer.to(cpu)
+
+            for idx, cfg in enumerate(loras_to_load):
+                # Create a unique name based on path and maybe a counter/hash
+                base_name = os.path.splitext(os.path.basename(cfg.path))[0]
+                safe_name = safe_adapter_name(base_name)
+                # Make name unique enough for dynamic changes
+                adapter_name = f"dyn_{safe_name}_{hash(cfg.path) % 10000}"
+                cfg.adapter_name = adapter_name
+
+                try:
+                    debug(f"Loading dynamic LoRA: '{cfg.path}' as '{adapter_name}'")
+                    load_lora(self.transformer, cfg.path, adapter_name=adapter_name)
+                    newly_loaded_loras.append(cfg)
+                except Exception as e:
+                    cfg.error = str(e)
+                    failed_dynamic.append(cfg)
+                    error_msg = f"Dynamic LoRA Load Failed: Could not load '{os.path.basename(cfg.path)}' as '{adapter_name}'. Reason: {e}"
+                    debug(f"[WARN] {error_msg}")
+                    if not self.lora_skip_fail:
+                        debug("[ERROR] Stopping due to dynamic LoRA load failure (--lora-skip-fail not set).")
+                        if original_device != cpu:
+                             self.transformer.to(original_device)
+                        raise RuntimeError(error_msg)
+                    else:
+                        debug("[WARN] Skipping failed dynamic LoRA as --lora-skip-fail is set.")
+
+            # Move back to original device
+            if original_device != cpu:
+                 debug(f"Moving transformer back to {original_device} after loading.")
+                 self.transformer.to(original_device)
+            debug("Finished loading new dynamic LoRAs.")
+
+
+        # --- Update State and Apply Adapters ---
+        # New set of dynamic configs = kept ones + newly loaded ones
+        self.dynamic_lora_configs = loras_to_keep + newly_loaded_loras
+        self.failed_dynamic_loras = failed_dynamic # Store failures from this run
+
+        # Update the combined active list
+        self._update_active_loras()
+
+        # Re-apply *all* currently active adapters (CLI + dynamic) with potentially updated weights
+        if self._active_loras:
+            adapter_names = [c.adapter_name for c in self._active_loras if c.adapter_name]
+            adapter_weights = [c.weight for c in self._active_loras if c.adapter_name]
+            debug(f"Applying {len(adapter_names)} total adapters (CLI + Dynamic) with weights: {adapter_weights}")
+            # Ensure transformer is on the correct target device before setting adapters
+            target_device = gpu if self.high_vram else cpu
+            if self.transformer.device != target_device:
+                debug(f"Ensuring transformer is on {target_device} before set_adapters.")
+                self.transformer.to(target_device)
+
+            set_adapters(self.transformer, adapter_names, adapter_weights)
+            debug("Adapters set successfully.")
+        else:
+            # If no LoRAs are active, ensure PEFT knows (might need explicit disabling)
+            try:
+                # Use PEFT's way to disable adapters if possible, otherwise this might be implicit
+                debug("No active LoRAs. Attempting to disable all adapters.")
+                self.transformer.disable_adapter_layers()
+                self.transformer.enable_adapter_layers() # Re-enable base layers? Check PEFT docs. Or maybe set_adapters with empty lists works?
+                # Safest might be:
+                # set_adapters(self.transformer, [], []) # Call with empty lists
+            except Exception as e:
+                 debug(f"Note: Could not explicitly disable adapters (might be okay): {e}")
+
+
+        debug(f"Dynamic LoRA update complete. Active dynamic: {len(self.dynamic_lora_configs)}, Failed this run: {len(failed_dynamic)}")
+        return self.dynamic_lora_configs, self.failed_dynamic_loras
+
+    # --- Rest of the ModelManager class ---
 
     def ensure_all_models_loaded(self):
         """If any required model is None, reload all models (auto-heals from accidental None)."""
@@ -68,128 +303,138 @@ class ModelManager:
         if missing:
             debug(f"[AutoReload] ModelManager reloading all models due to missing: {missing}")
             # Always reload all at once
-            self.load_all_models()
+            self.load_all_models() # This should also reload CLI LoRAs
         # Recheck
         still_missing = [name for name in required_attrs if getattr(self, name, None) is None]
         if still_missing:
             debug(f"[FATAL] After reload, still missing: {still_missing}")
             raise RuntimeError(f"Failed to reload required models: {still_missing}")
-    
+
     def load_all_models(self):
         """Load all required models based on VRAM configuration"""
         try:
             debug("Starting model loading process")
-            # Load models from pretrained
+            # --- Model Loading Code (existing, unchanged) ---
             from transformers import LlamaModel, CLIPTextModel, LlamaTokenizerFast, CLIPTokenizer
             from diffusers import AutoencoderKLHunyuanVideo
             from transformers import SiglipImageProcessor, SiglipVisionModel
             from diffusers_helper.models.hunyuan_video_packed import HunyuanVideoTransformer3DModelPacked
-            
+
             # Load all models to CPU initially
             debug("Loading text encoders and tokenizers")
             self.text_encoder = LlamaModel.from_pretrained(
-                "hunyuanvideo-community/HunyuanVideo", 
-                subfolder='text_encoder', 
+                "hunyuanvideo-community/HunyuanVideo",
+                subfolder='text_encoder',
                 torch_dtype=torch.float16
             ).cpu()
             self.text_encoder_2 = CLIPTextModel.from_pretrained(
-                "hunyuanvideo-community/HunyuanVideo", 
-                subfolder='text_encoder_2', 
+                "hunyuanvideo-community/HunyuanVideo",
+                subfolder='text_encoder_2',
                 torch_dtype=torch.float16
             ).cpu()
-            
+
             self.tokenizer = LlamaTokenizerFast.from_pretrained(
-                "hunyuanvideo-community/HunyuanVideo", 
+                "hunyuanvideo-community/HunyuanVideo",
                 subfolder='tokenizer'
             )
-            
+
             self.tokenizer_2 = CLIPTokenizer.from_pretrained(
-                "hunyuanvideo-community/HunyuanVideo", 
+                "hunyuanvideo-community/HunyuanVideo",
                 subfolder='tokenizer_2'
             )
-            
+
             debug("Loading VAE")
             self.vae = AutoencoderKLHunyuanVideo.from_pretrained(
-                "hunyuanvideo-community/HunyuanVideo", 
-                subfolder='vae', 
+                "hunyuanvideo-community/HunyuanVideo",
+                subfolder='vae',
                 torch_dtype=torch.float16
             ).cpu()
-            
+
             debug("Loading image encoder components")
             self.feature_extractor = SiglipImageProcessor.from_pretrained(
-                "lllyasviel/flux_redux_bfl", 
+                "lllyasviel/flux_redux_bfl",
                 subfolder='feature_extractor'
             )
-            
+
             self.image_encoder = SiglipVisionModel.from_pretrained(
-                "lllyasviel/flux_redux_bfl", 
-                subfolder='image_encoder', 
+                "lllyasviel/flux_redux_bfl",
+                subfolder='image_encoder',
                 torch_dtype=torch.float16
             ).cpu()
-            
+
             debug("Loading transformer model")
             self.transformer = HunyuanVideoTransformer3DModelPacked.from_pretrained(
-                'lllyasviel/FramePackI2V_HY', 
+                'lllyasviel/FramePackI2V_HY',
                 torch_dtype=torch.bfloat16
             ).cpu()
-            
+             # --- End Model Loading Code ---
+
             # Configure models
             debug("Configuring models")
             for m in [self.vae, self.text_encoder, self.text_encoder_2, self.image_encoder, self.transformer]:
                 if m is not None:
                     m.eval()
-            
+
             # Configure VAE for low VRAM
             if not self.high_vram:
                 self.vae.enable_slicing()
                 self.vae.enable_tiling()
-            
+
             # Configure transformer for high quality output
             self.transformer.high_quality_fp32_output_for_inference = True
             debug('transformer.high_quality_fp32_output_for_inference = True')
-            
+
             # Set model dtypes
             self.transformer.to(dtype=torch.bfloat16)
             self.vae.to(dtype=torch.float16)
             self.image_encoder.to(dtype=torch.float16)
             self.text_encoder.to(dtype=torch.float16)
             self.text_encoder_2.to(dtype=torch.float16)
-            
+
             # Make sure no gradients are computed
             for m in [self.vae, self.text_encoder, self.text_encoder_2, self.image_encoder, self.transformer]:
                 if m is not None:
                     m.requires_grad_(False)
-            
-            # Handle device placement based on VRAM - like original code
+
+            # Handle device placement based on VRAM
             if not self.high_vram:
                 debug("Low VRAM mode: Using dynamic swapping")
-                # Use DynamicSwapInstaller from the original code
                 DynamicSwapInstaller.install_model(self.transformer, device=gpu)
                 DynamicSwapInstaller.install_model(self.text_encoder, device=gpu)
+                # Add others if necessary for swapping
+                # DynamicSwapInstaller.install_model(self.text_encoder_2, device=gpu)
+                # DynamicSwapInstaller.install_model(self.image_encoder, device=gpu)
+                # DynamicSwapInstaller.install_model(self.vae, device=gpu)
             else:
                 debug("High VRAM mode: Moving all models to GPU")
+                # Move base models first
                 for m in [self.text_encoder, self.text_encoder_2, self.image_encoder, self.vae, self.transformer]:
                     if m is not None:
                         m.to(gpu)
 
-            # Load LoRAs after transformer is ready
-            if self.lora_configs:
-                self.load_loras()
-                if self.high_vram:
-                    self.transformer.to(gpu)
-                else:
-                    self.transformer.to(cpu)
+            # Load CLI LoRAs after transformer is ready and on its initial device
+            if self.cli_lora_configs:
+                 self.load_cli_loras() # This handles moving transformer and setting adapters
+
             self.models_loaded = True
             debug("All models loaded successfully")
+            # Final check on transformer device
+            expected_device = gpu if self.high_vram else cpu
+            if self.transformer and self.transformer.device != expected_device:
+                 debug(f"[WARN] Transformer device is {self.transformer.device}, expected {expected_device} after load_all_models.")
+                 # Force move if needed, though load_cli_loras should handle it
+                 # self.transformer.to(expected_device)
             return True
-            
+
         except Exception as e:
             debug(f"Error loading models: {e}")
             import traceback
             debug(traceback.format_exc())
             self.models_loaded = False
+            # Attempt cleanup
+            self.unload_all_models()
             return False
-    
+
     def initialize_teacache(self, enable_teacache=True, num_steps=0):
         """Initialize transformer TeaCache setting"""
         if self.transformer is not None:
@@ -203,47 +448,125 @@ class ModelManager:
             debug("Cannot initialize TeaCache: transformer not loaded")
             return False
 
+    # --- Updated unload_all_models ---
     def unload_all_models(self):
         """
-        Unload all models completely from memory (both CPU and GPU)
-        
-        This clears all model references to fully free memory
+        Unload all models completely from memory (both CPU and GPU),
+        including deleting any attached LoRA adapters.
         """
+        debug("--- Starting Full Model Unload ---")
         try:
-            # First move everything to CPU to free GPU memory
+            # 1. Delete LoRA Adapters from Transformer (if it exists)
+            if hasattr(self, 'transformer') and self.transformer is not None:
+                debug("Attempting to delete LoRA adapters from transformer...")
+                original_device = cpu
+                try:
+                    # Check if transformer has parameters to get device
+                    if next(self.transformer.parameters(), None) is not None:
+                        original_device = next(self.transformer.parameters()).device
+                        if original_device != cpu:
+                            debug("Moving transformer to CPU before deleting adapters.")
+                            self.transformer.to(cpu)
+                    else:
+                         debug("Transformer has no parameters, assuming CPU.")
+
+                    # Get all potential adapter names from our tracked configs
+                    all_adapter_names = set()
+                    for cfg in self.applied_cli_loras + self.dynamic_lora_configs:
+                        if cfg.adapter_name:
+                            all_adapter_names.add(cfg.adapter_name)
+
+                    if all_adapter_names:
+                        debug(f"Found adapter names to delete: {list(all_adapter_names)}")
+                        # Use PEFT's method to see currently loaded adapters
+                        if hasattr(self.transformer, 'delete_adapter'):
+                             # It's safer to check what PEFT thinks is loaded
+                            loaded_adapters = []
+                            if hasattr(self.transformer, 'active_adapters'):
+                                loaded_adapters.extend(self.transformer.active_adapters)
+                            if hasattr(self.transformer, 'adapters'): # Backup check
+                                loaded_adapters.extend(list(self.transformer.adapters.keys()))
+
+                            adapters_to_delete = set(loaded_adapters) & all_adapter_names
+                            debug(f"Adapters PEFT knows about that we tracked: {list(adapters_to_delete)}")
+
+                            for name in adapters_to_delete:
+                                try:
+                                    debug(f"Deleting adapter '{name}'...")
+                                    self.transformer.delete_adapter(name)
+                                    debug(f"Successfully deleted adapter '{name}'.")
+                                except Exception as e:
+                                    debug(f"Error deleting adapter '{name}': {e}")
+                            # Also try disabling just in case delete leaves things active
+                            if hasattr(self.transformer, 'disable_adapter_layers'):
+                                self.transformer.disable_adapter_layers()
+                        else:
+                             debug("Transformer does not have 'delete_adapter' method. Skipping deletion.")
+                    else:
+                        debug("No tracked adapter names found to delete.")
+
+                except Exception as e:
+                    debug(f"Error during adapter deletion preparation: {e}")
+                finally:
+                    # Clear our tracking lists regardless of success
+                    self.applied_cli_loras = []
+                    self.dynamic_lora_configs = []
+                    self._active_loras = []
+                    debug("Cleared internal LoRA tracking lists.")
+                    # No need to move transformer back here, it will be deleted next
+
+            # 2. Move models to CPU (redundant if already done for adapters, but safe)
             if self.models_loaded:
+                debug("Moving any remaining loaded models to CPU...")
                 for model_attr in ['text_encoder', 'text_encoder_2', 'image_encoder', 'vae', 'transformer']:
-                    if hasattr(self, model_attr) and getattr(self, model_attr) is not None:
+                    model = getattr(self, model_attr, None)
+                    if model is not None and hasattr(model, 'device') and model.device != cpu:
                         try:
-                            model = getattr(self, model_attr)
-                            model.to('cpu')
+                            model.to(cpu)
                             debug(f"Moved {model_attr} to CPU")
                         except Exception as e:
-                            debug(f"Error moving {model_attr} to CPU: {e}")
-            
-            # Clear CUDA cache
-            torch.cuda.empty_cache()
-            
-            # Set all model references to None
+                            debug(f"Error moving {model_attr} to CPU during unload: {e}")
+
+            # 3. Clear CUDA Cache (important before deleting refs)
+            if torch.cuda.is_available():
+                debug("Clearing CUDA cache...")
+                clear_cuda_cache()
+
+            # 4. Delete model references
+            debug("Deleting model references...")
             self.text_encoder = None
-            self.text_encoder_2 = None 
+            self.text_encoder_2 = None
             self.image_encoder = None
             self.vae = None
             self.transformer = None
-            
+            # Also clear tokenizers/processors
+            self.tokenizer = None
+            self.tokenizer_2 = None
+            self.feature_extractor = None
+
             # Mark models as unloaded
             self.models_loaded = False
-            
-            # Force garbage collection
+
+            # 5. Force Garbage Collection
+            debug("Running garbage collection...")
             import gc
             gc.collect()
-            
+
             # Report free memory
-            free_mem = get_cuda_free_memory_gb(gpu)
-            debug(f"All models completely unloaded. Free VRAM: {free_mem:.2f} GB")
+            free_mem = get_cuda_free_memory_gb(gpu) if torch.cuda.is_available() else 0
+            debug(f"--- Full Model Unload Complete --- Free VRAM: {free_mem:.2f} GB")
             return True
         except Exception as e:
-            debug(f"Error completely unloading models: {e}")
+            debug(f"Error during full model unload: {e}")
             import traceback
             debug(traceback.format_exc())
+            # Attempt partial cleanup
+            self.models_loaded = False
+            self.text_encoder = None
+            self.text_encoder_2 = None
+            # ... etc ...
+            self.transformer = None
+            self.applied_cli_loras = []
+            self.dynamic_lora_configs = []
+            self._active_loras = []
             return False

--- a/utils/prompt_parser.py
+++ b/utils/prompt_parser.py
@@ -1,81 +1,183 @@
 # utils/prompt_parser.py
 from typing import List, Dict, Any, Callable, Optional, Union, Tuple
+import re
+import os
 from utils.common import debug
+# Import LoRAConfig from lora_utils
+from utils.lora_utils import LoRAConfig
 
 class PromptProcessor:
     """Base class for prompt processors"""
     def __init__(self, name: str):
         self.name = name
-        
+
     def process(self, prompt_text: str) -> str:
         """Process a prompt and return the modified prompt"""
         return prompt_text
-        
+
     def extract_data(self, prompt_text: str) -> Dict[str, Any]:
         """Extract data from a prompt without modifying it"""
         return {}
 
+class LoraPromptProcessor(PromptProcessor):
+    """
+    Extracts LoRA specifications like [path/to/lora:weight] or [/abs/path/lora]
+    from the prompt text and removes them.
+    """
+    # Regex explanation:
+    # \[             # Match opening square bracket
+    # (              # Start capture group 1 (path)
+    #   [^:\]]+     # Match one or more characters that are NOT ':' or ']'
+    # )              # End capture group 1
+    # (?:            # Start non-capturing group for optional weight
+    #   :            # Match the colon separator
+    #   (\d+\.?\d*) # Capture group 2 (weight): one or more digits, optional decimal part
+    # )?             # End non-capturing group, make it optional
+    # \]             # Match closing square bracket
+    LORA_REGEX = re.compile(r"\[([^:\]]+?)(?::(\d+\.?\d*))?\]")
+
+    def __init__(self):
+        super().__init__("lora")
+
+    def _normalize_path(self, path_fragment: str) -> Optional[str]:
+        """Adds .safetensors if missing and checks existence."""
+        path_fragment = path_fragment.strip()
+        # Try absolute path first
+        potential_path_abs = Path(path_fragment)
+        potential_path_abs_st = Path(f"{path_fragment}.safetensors")
+
+        # Try relative path (assuming a standard 'loras' folder might exist)
+        # Adjust './loras/' if your LoRA directory is different or configurable
+        lora_dir = Path('./loras/') 
+        potential_path_rel = lora_dir / path_fragment
+        potential_path_rel_st = lora_dir / f"{path_fragment}.safetensors"
+
+
+        # Check existence in order: abs, abs+.st, rel, rel+.st
+        if potential_path_abs.is_file():
+            return str(potential_path_abs.resolve())
+        if potential_path_abs_st.is_file():
+             return str(potential_path_abs_st.resolve())
+        if potential_path_rel.is_file():
+             return str(potential_path_rel.resolve())
+        if potential_path_rel_st.is_file():
+             return str(potential_path_rel_st.resolve())
+
+        debug(f"[LoraParser] LoRA file not found for spec: '{path_fragment}' (checked . and .safetensors)")
+        return None # Indicate not found
+
+    def extract_data(self, prompt_text: str) -> Dict[str, Any]:
+        """Extracts LoRAConfig objects from the prompt."""
+        lora_configs = []
+        matches = self.LORA_REGEX.finditer(prompt_text)
+        for match in matches:
+            path_fragment = match.group(1)
+            weight_str = match.group(2)
+
+            normalized_path = self._normalize_path(path_fragment)
+            if normalized_path:
+                weight = float(weight_str) if weight_str else 1.0
+                lora_configs.append(LoRAConfig(path=normalized_path, weight=weight))
+            else:
+                # Store the failure attempt for potential error reporting later
+                lora_configs.append(LoRAConfig(path=path_fragment, weight=1.0, error=f"File not found"))
+
+
+        debug(f"[LoraParser] Extracted LoRA configs: {lora_configs}")
+        return {"lora_configs": lora_configs}
+
+    def process(self, prompt_text: str) -> str:
+        """Removes the LoRA specifications from the prompt text."""
+        cleaned_prompt = self.LORA_REGEX.sub("", prompt_text).strip()
+        # Clean up potential extra spaces left by removal
+        cleaned_prompt = re.sub(r'\s{2,}', ' ', cleaned_prompt)
+        debug(f"[LoraParser] Cleaned prompt: '{cleaned_prompt}'")
+        return cleaned_prompt
+
+
 def parse_sequential_prompts(prompt_text: str) -> List[str]:
     """
     Parse a prompt text with semicolons into a list of sequential prompts.
-    
+
     Args:
         prompt_text: Full prompt text with semicolons
-        
+
     Returns:
         List of individual prompts, stripped of whitespace
     """
     if not prompt_text:
         return []
-        
+
     # Split by semicolons and strip whitespace
     prompts = [p.strip() for p in prompt_text.split(';') if p.strip()]
-    
+
     if not prompts:
-        return [prompt_text.strip()]  # Return original if splitting resulted in empty list
-        
-    debug(f"Parsed {len(prompts)} sequential prompts: {prompts}")
+        # If splitting results in nothing, but original had content, return original
+        original_stripped = prompt_text.strip()
+        return [original_stripped] if original_stripped else []
+
+    # debug(f"Parsed {len(prompts)} sequential prompts: {prompts}") # Debug moved to generation.py
     return prompts
 
+
+class SequentialPromptProcessor(PromptProcessor):
+    """Process prompts with semicolons for sequential generation"""
+    def __init__(self):
+        super().__init__("sequential")
+
+    def extract_data(self, prompt_text: str) -> Dict[str, Any]:
+        """Extract sequential prompts without modifying the original"""
+        prompts = parse_sequential_prompts(prompt_text)
+        return {
+            "prompts": prompts,
+            "is_sequential": len(prompts) > 1
+        }
+
+    def process(self, prompt_text: str) -> str:
+        """For sequential processing, we keep the original prompt for splitting later"""
+        # The actual splitting happens in generate_video after LoRAs are handled
+        return prompt_text
+
+
+# --- Updated apply_prompt_processors ---
 def apply_prompt_processors(prompt_text: str, processors: List[PromptProcessor]) -> Tuple[str, Dict[str, Any]]:
     """
     Apply a series of prompt processors to extract data and transform a prompt.
-    This generic function allows for multiple types of processing in sequence.
-    
+    Ensures LoRA processing happens first if included.
+
     Args:
         prompt_text: Original prompt text
         processors: List of PromptProcessor objects to apply
-        
+
     Returns:
         Tuple of (modified_prompt, extracted_data)
     """
     modified_prompt = prompt_text
     extracted_data = {}
-    
-    for processor in processors:
-        # Extract data without modifying the prompt
+
+    # Ensure LoraPromptProcessor runs first if present
+    lora_processor = next((p for p in processors if isinstance(p, LoraPromptProcessor)), None)
+    other_processors = [p for p in processors if not isinstance(p, LoraPromptProcessor)]
+
+    # Process LoRAs first
+    if lora_processor:
+        debug(f"Applying LoRA processor: {lora_processor.name}")
+        processor_data = lora_processor.extract_data(modified_prompt)
+        extracted_data[lora_processor.name] = processor_data
+        modified_prompt = lora_processor.process(modified_prompt) # Clean the prompt
+        debug(f"After LoRA processing - Cleaned Prompt: '{modified_prompt}', Data: {processor_data}")
+
+
+    # Process remaining processors on the (potentially cleaned) prompt
+    for processor in other_processors:
+        debug(f"Applying processor: {processor.name}")
+        # Extract data based on the current state of modified_prompt
         processor_data = processor.extract_data(modified_prompt)
         extracted_data[processor.name] = processor_data
-        
-        # Apply the processor to modify the prompt
+        # Process modifies the prompt further (if the processor does so)
         modified_prompt = processor.process(modified_prompt)
-        
-    return modified_prompt, extracted_data
+        debug(f"After {processor.name} processing - Prompt: '{modified_prompt}', Data: {processor_data}")
 
-# Example specialized processor for sequential prompts
-class SequentialPromptProcessor(PromptProcessor):
-    """Process prompts with semicolons for sequential generation"""
-    def __init__(self):
-        super().__init__("sequential")
-        
-    def extract_data(self, prompt_text: str) -> Dict[str, Any]:
-        """Extract sequential prompts without modifying the original"""
-        prompts = parse_sequential_prompts(prompt_text)
-        return {
-            "prompts": prompts, 
-            "is_sequential": len(prompts) > 1
-        }
-        
-    def process(self, prompt_text: str) -> str:
-        """For sequential processing, we keep the original prompt"""
-        return prompt_text
+
+    debug(f"Final result - Modified Prompt: '{modified_prompt}', All Extracted Data: {extracted_data}")
+    return modified_prompt, extracted_data

--- a/utils/prompt_parser.py
+++ b/utils/prompt_parser.py
@@ -2,6 +2,7 @@
 from typing import List, Dict, Any, Callable, Optional, Union, Tuple
 import re
 import os
+from pathlib import Path # <-- ADD THIS LINE
 from utils.common import debug
 # Import LoRAConfig from lora_utils
 from utils.lora_utils import LoRAConfig


### PR DESCRIPTION
## Release Notes: Dynamic Multi-LoRA Loading & Sequential Prompt Fix

This update introduces the ability to dynamically load multiple LoRA adapters directly from the generation prompt, offering greater flexibility for styling and concept experimentation. It also includes important stability fixes and adjustments to sequential prompt handling.

**⭐ New Features:**

*   **Dynamic LoRA Loading via Prompt:** You can now specify LoRA files directly within the main prompt text using bracket syntax:
    *   `[path/to/your/lora]` (uses default weight 1.0)
    *   `[path/to/your/lora:0.75]` (specifies a custom weight)
    *   The `.safetensors` extension is optional.
    *   Supports multiple LoRAs: `[lora1:0.5] [lora2] A description...`
    *   Paths can be absolute or relative (searches relative to a `./loras/` directory by default).
*   **Automatic Prompt Cleaning:** LoRA specifications are automatically detected, extracted, and removed from the prompt text before it's used for text encoding. The cleaned prompt is used for generation.
*   **Distinct LoRA Lifecycles:**
    *   **CLI LoRAs (`--lora`):** Remain active for the entire session ("sticky").
    *   **Dynamic LoRAs (Prompt):** Loaded *specifically* for the generation triggered by that prompt and automatically **unloaded** afterwards if not specified again in the next prompt, conserving resources.

**🔧 Fixes & Improvements:**

*   **Correct LoRA Unloading:** Fixed the `Unload All Models` function. It now properly deletes all attached LoRA adapters (CLI and dynamic) before unloading base models, resolving previous errors.
*   **Sequential Prompt Order:** Adjusted the processing order for sequential prompts (separated by ';'). This aims to better align the prompt segments with the generated video sections. *Note: The very first generated segment (corresponding to the last part of the video) may still feel slightly misaligned with its intended prompt; further investigation is ongoing.*
*   **Resolved NameErrors:** Fixed errors related to missing imports (`pathlib.Path`) and incorrect variable usage during prompt processing and encoding.

**📝 Usage Example (Prompt):**

```
A beautiful landscape painting [style_impressionism:0.8] [artist_monet] showing waterlilies; a close-up of a single waterlily [style_photorealistic:0.9]
```

*   In this example:
    *   `[style_impressionism:0.8]` and `[artist_monet]` will be loaded dynamically for this generation.
    *   Any LoRAs loaded via `--lora` at startup will also be active.
    *   The actual prompts sent for encoding will be:
        1.  `A beautiful landscape painting showing waterlilies`
        2.  `a close-up of a single waterlily`
    *   After this generation, if the next prompt omits these dynamic LoRAs, they will be unloaded.